### PR TITLE
refactor(graphql)!: simplify websocket handling

### DIFF
--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -11,14 +11,11 @@ import { env } from '@/config/environment';
 import { initLoaders } from './init-loaders';
 import { handleError } from '@/errors';
 import type { Server } from 'http';
-import { execute, subscribe } from 'graphql';
 import { IContext } from '@/shared/interfaces';
 import { UUIDv4 } from '@/shared/types';
 import Session, { SessionInformation } from 'supertokens-node/recipe/session';
 import { WebSocketServer } from 'ws';
 import { useServer } from 'graphql-ws/lib/use/ws';
-import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from 'graphql-ws';
-import { SubscriptionServer, GRAPHQL_WS } from 'subscriptions-transport-ws';
 import {
   ApolloServerPluginLandingPageLocalDefault,
   ApolloServerPluginLandingPageProductionDefault,
@@ -44,11 +41,63 @@ interface IGraphQLSubscriptionConnectionParams {
 
 export const initApolloGraphqlServer = async (app: Express, httpServer: Server): Promise<void> => {
   const GRAPHQL_PATH = '/graphql';
-
   const schema = initializeSchema();
+
+  ///////////////////////////////////////
+  // Setup GraphQL Subscription Server //
+  ///////////////////////////////////////
+
+  const wsServer = new WebSocketServer({
+    server: httpServer,
+    path: GRAPHQL_PATH,
+  });
+  const serverCleanup = useServer(
+    {
+      schema,
+      context: async (ctx): Promise<IGraphQLSubscriptionContext> => {
+        // As for why we're taking `connectionParams` as an example is because it's what you can pass from Apollo CLient
+        // https://www.apollographql.com/docs/apollo-server/data/subscriptions/#example-authentication-with-apollo-client
+        const connectionParams = (ctx.connectionParams ?? {}) as IGraphQLSubscriptionConnectionParams;
+
+        let userId: UUIDv4 | null = null;
+        if (connectionParams.sessionHandle) {
+          const sessionHandle = connectionParams.sessionHandle as string;
+
+          const sessionInformation: SessionInformation | undefined = await Session.getSessionInformation(sessionHandle).catch();
+
+          userId = sessionInformation?.userId ?? null;
+        }
+
+        return {
+          userId,
+        };
+      },
+      onConnect: async (ctx) => {
+        if (!env.isProduction) console.info('Client connected');
+
+        /**
+         * FIXME: Think about how you want to handle your authentication with WebSockets.
+         * You could check `sessionHandle` from `connectionParams` here and return false if it's invalid.
+         *
+         * Here are some recipes you can use as reference:
+         * - https://the-guild.dev/graphql/ws/recipes#server-usage-with-ws-and-custom-auth-handling
+         * - https://the-guild.dev/graphql/ws/recipes#ws-server-and-client-auth-usage-with-token-expiration-validation-and-refresh
+         */
+      },
+      onDisconnect: () => {
+        if (!env.isProduction) console.info('Client disconnected');
+      },
+    },
+    wsServer,
+  );
+
+  /////////////////////////
+  // Setup Apollo Server //
+  /////////////////////////
 
   const apolloServer = new ApolloServer<IGraphQLContext>({
     schema,
+    introspection: !env.isProduction,
 
     formatError: (gqlFormattedError, error) => {
       const err = handleError(error as Error);
@@ -63,13 +112,21 @@ export const initApolloGraphqlServer = async (app: Express, httpServer: Server):
         },
       };
     },
-
     validationRules: [depthLimit(10)],
-
-    introspection: !env.isProduction,
-
     plugins: [
+      // Proper shutdown for the HTTP Server.
       ApolloServerPluginDrainHttpServer({ httpServer }),
+      // Proper shutdown for the WebSocket Server.
+      {
+        async serverWillStart() {
+          return {
+            async drainServer() {
+              await serverCleanup.dispose();
+            },
+          };
+        },
+      },
+      // GraphQL endpoint landing page.
       env.isProduction
         ? ApolloServerPluginLandingPageProductionDefault()
         : ApolloServerPluginLandingPageLocalDefault({ includeCookies: true }),
@@ -79,7 +136,6 @@ export const initApolloGraphqlServer = async (app: Express, httpServer: Server):
     // https://www.apollographql.com/docs/apollo-server/migration/#appropriate-400-status-codes
     status400ForVariableCoercionErrors: true,
   });
-
   await apolloServer.start();
 
   app.use(
@@ -99,132 +155,4 @@ export const initApolloGraphqlServer = async (app: Express, httpServer: Server):
       },
     }),
   );
-
-  /**
-   * It'll get messy below but there's an issue currently with the state of the protocols that can be used (subscriptions-transport-ws vs graphql-ws).
-   * Read more from: https://www.apollographql.com/docs/apollo-server/data/subscriptions/#the-graphql-ws-transport-library
-   *
-   * Bottomline is, if we use the newer and actively maintained `graphql-ws` lib, then the GraphQL Playground will not work because it uses the old protocol.
-   *
-   * The approach below tries to support both based on the template provided here but adjusted for our setup here.
-   * https://github.com/enisdenjo/graphql-ws#ws-backwards-compat
-   */
-
-  async function createContextFromConnectionParams(
-    connectionParams: IGraphQLSubscriptionConnectionParams,
-  ): Promise<IGraphQLSubscriptionContext> {
-    let userId: UUIDv4 | null = null;
-    if (connectionParams.sessionHandle) {
-      const sessionInformation: SessionInformation | undefined = await Session.getSessionInformation(
-        connectionParams.sessionHandle,
-      ).catch();
-      userId = sessionInformation?.userId ?? null;
-    }
-
-    const context: IGraphQLSubscriptionContext = {
-      userId,
-    };
-
-    return context;
-  }
-
-  // graphql-ws
-  const graphqlWs = new WebSocketServer({
-    path: GRAPHQL_PATH,
-    noServer: true,
-  });
-  useServer(
-    {
-      schema,
-      execute,
-      subscribe,
-
-      // https://github.com/enisdenjo/graphql-ws/issues/189#issuecomment-851008738
-      context: (ctx) => ctx.extra.context,
-      onConnect: ({ connectionParams, extra }) => {
-        if (!env.isProduction) console.info('connected');
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        extra.context = createContextFromConnectionParams(connectionParams as IGraphQLSubscriptionConnectionParams);
-      },
-      onDisconnect: ({ connectionParams }) => {
-        if (!env.isProduction) console.info('disconnected');
-      },
-    },
-    graphqlWs,
-  );
-
-  // subscriptions-transport-ws
-  const subscriptionTransportWs = SubscriptionServer.create(
-    {
-      schema,
-      execute,
-      subscribe,
-
-      // See https://www.apollographql.com/docs/graphql-subscriptions/lifecycle-events/
-      onConnect: async (
-        connectionParams: IGraphQLSubscriptionConnectionParams,
-        webSocket: Record<string, unknown>,
-        connectionContext: Record<string, unknown>,
-      ) => {
-        if (!env.isProduction) console.info('connected');
-
-        // https://www.apollographql.com/docs/graphql-subscriptions/authentication/
-        // If you've checked the link above, Apollo's example centralizes the authentication logic in here.
-        // However, you need to think about your requirements. For example, you have a chat feature
-        // and the user can be kicked out of the chat any time and cannot read chat anymore.
-        // Then the approach from Apollo's example wouldn't work because the socket connection would
-        // still be alive since this lifecycle event will only be called once. You could set the `keepAlive`
-        // property an interval value so that they get disconnected based on that but that isn't recommended
-        // either. So how should you go about handling it?
-
-        // There are multiple ways to go about this depending on your requirements. I suggest
-        // checking this repo: https://github.com/viktor-br/gql-subscriptions-auth
-        // Just keep in mind that as of Apollo Server 3, the subscription server has been separated
-        // from the apollo server so the "context" approach will not work anymore (marker "D") from
-        // https://github.com/viktor-br/gql-subscriptions-auth#authentication-and-authorization
-
-        return createContextFromConnectionParams(connectionParams);
-      },
-      onDisconnect: (webSocket: Record<string, unknown>, context: Record<string, unknown>) => {
-        if (!env.isProduction) console.info('disconnected');
-      },
-    },
-    {
-      path: GRAPHQL_PATH,
-      noServer: true,
-    },
-  );
-
-  // listen for upgrades and delegate requests according to the WS subprotocol
-  httpServer.on('upgrade', (req, socket, head) => {
-    // extract websocket subprotocol from header
-    const protocol = req.headers['sec-websocket-protocol'];
-    const protocols = Array.isArray(protocol) ? protocol : protocol?.split(',').map((p: string) => p.trim());
-
-    // decide which websocket server to use
-    const wss =
-      protocols?.includes(GRAPHQL_WS) && // subscriptions-transport-ws subprotocol
-      !protocols.includes(GRAPHQL_TRANSPORT_WS_PROTOCOL) // graphql-ws subprotocol
-        ? subscriptionTransportWs.server
-        : // graphql-ws will welcome its own subprotocol and
-          // gracefully reject invalid ones. if the client supports
-          // both transports, graphql-ws will prevail
-          graphqlWs;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    wss.handleUpgrade(req, socket as any /* believe lol */, head, (ws) => {
-      wss.emit('connection', ws, req);
-    });
-  });
-
-  // Shut down in the case of interrupt and termination signals
-  // We expect to handle this more cleanly in the future. See (#5074)[https://github.com/apollographql/apollo-server/issues/5074] for reference.
-  ['SIGINT', 'SIGTERM'].forEach((signal) => {
-    process.on(signal, () => {
-      httpServer.close();
-      process.exit();
-    });
-  });
 };


### PR DESCRIPTION
Got rid of mixing between the old and new protocols and instead opted for the latest and stable one since `subscriptions-transport-ws` has been deprecated now.

In the scenario that your Apollo Clients are still relying on the old protocol, here's a table comparing which lib to use.

https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws